### PR TITLE
Fix a `Promise <pending>` issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,5 +39,8 @@ module.exports = {
   gyp: gyp,
   isNodeApiBuiltin: isNodeApiBuiltin,
   needsFlag: needsFlag,
-  generate: require('./generator').main
+  generate: () => {
+    require('./generator').main()
+    return '';
+  }
 };


### PR DESCRIPTION
When running `npm test` command, `Promise <pending>` was printed out.
This change fixes the issue.