### PR TITLE
Set cwd as examples for npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "url": "git://github.com/nodejs/node-addon-api.git"
   },
   "scripts": {
-    "test": "node -p \"require('node-addon-api').generate()\"",
+    "test": "cd examples && node -p \"require('node-addon-api').generate()\"",
     "doc": "doxygen doc/Doxyfile",
     "start": "node-gyp rebuild -C examples && node examples/hello.js"
   },


### PR DESCRIPTION
When user commands "npm test", the current directory is set to where
package.json is located wherever user is. So I added "cd examples"
before node evaluation.